### PR TITLE
fix: increase repetition context threshold

### DIFF
--- a/src/pages/editor/completion/repetitionFilter.ts
+++ b/src/pages/editor/completion/repetitionFilter.ts
@@ -154,7 +154,7 @@ export function isRepetitive(
   } = {},
 ): boolean {
   const {
-    contextThreshold = 0.6,
+    contextThreshold = 0.9,
     selfThreshold = 0.5,
     checkPatterns = true,
   } = options


### PR DESCRIPTION
Increases the context repetition threshold from 0.6 to 0.9 to reduce false positives when detecting repetitive completions.

The previous threshold of 0.6 was too sensitive and would reject valid completions that had moderate similarity to the surrounding context. Raising it to 0.9 allows more natural completions while still filtering out truly repetitive suggestions.