### PR TITLE
feat: add in-app model download UI and management

### DIFF
--- a/src/components/ActivityIndicator.tsx
+++ b/src/components/ActivityIndicator.tsx
@@ -6,11 +6,13 @@ import { v4 as uuidv4 } from 'uuid'
 export interface ActivityIndicatorProps extends PropsWithChildren {
   srOnly?: boolean
   className?: string
+  iconClassName?: string
 }
 
 export function ActivityIndicator({
   children = 'Loading...',
   className,
+  iconClassName,
   srOnly,
 }: ActivityIndicatorProps) {
   const id = `activity-indicator-${uuidv4()}`
@@ -24,7 +26,7 @@ export function ActivityIndicator({
       )}
       aria-labelledby={id}
     >
-      <Loader2 className="size-4 animate-spin" />
+      <Loader2 className={cn('size-4 animate-spin', iconClassName)} />
       <span id={id} className={cn(srOnly && 'sr-only')}>
         {children}
       </span>

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/utils'
-import { PropsWithChildren, useEffect, useState } from 'react'
+import { PropsWithChildren } from 'react'
 import { useDebounceValue } from 'usehooks-ts'
 
 export interface ToastProps {
@@ -14,27 +14,7 @@ export function Toast({
   className,
   children,
 }: PropsWithChildren<ToastProps>) {
-  const [collapse, setCollapse] = useState(false)
-
-  const [preventRender] = useDebounceValue(!visible, 250)
-
-  useEffect(() => {
-    let timeout: ReturnType<typeof setTimeout>
-
-    if (visible) {
-      setCollapse(false)
-    } else {
-      timeout = setTimeout(() => {
-        setCollapse(true)
-      }, hideDelay)
-    }
-
-    return () => {
-      if (timeout) {
-        clearTimeout(timeout)
-      }
-    }
-  }, [hideDelay, visible])
+  const [preventRender] = useDebounceValue(!visible, hideDelay)
 
   if (preventRender) {
     return null
@@ -44,7 +24,7 @@ export function Toast({
     <div
       className={cn(
         'bg-neutral-200/20 dark:bg-neutral-800/20 backdrop-blur-xl border border-border rounded-md pl-3 pr-1.5 py-2 motion-safe:transition-opacity text-sm flex items-center justify-between gap-12 shadow-xs min-h-12.5',
-        collapse ? 'pointer-events-none opacity-0' : 'opacity-100',
+        !visible ? 'pointer-events-none opacity-0' : 'opacity-100',
         className,
       )}
     >

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -28,7 +28,7 @@ export function Toast({
   return (
     <div
       className={cn(
-        'bg-neutral-200/20 dark:bg-neutral-800/20 backdrop-blur-xl border border-border rounded-md pl-3 pr-1.5 py-2 motion-safe:transition-opacity text-sm flex items-center justify-between gap-12 shadow-xs min-h-12.5 font-medium',
+        'bg-neutral-200/20 dark:bg-neutral-800/20 backdrop-blur-xl border border-border rounded-md pl-3 pr-1.5 py-2 motion-safe:transition-opacity text-sm flex items-center justify-between gap-12 shadow-xs min-h-12.5',
         !visible ? 'pointer-events-none opacity-0' : 'opacity-100',
         className,
       )}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,25 +1,37 @@
 import { cn } from '@/lib/utils'
-import { PropsWithChildren, useState } from 'react'
-import { useInterval } from 'usehooks-ts'
+import { PropsWithChildren, useEffect, useState } from 'react'
 
 export interface ToastProps {
   visible?: boolean
+  hideDelay?: number
   className?: string
 }
 
 export function Toast({
   visible,
+  hideDelay = 250,
   className,
   children,
 }: PropsWithChildren<ToastProps>) {
   const [collapse, setCollapse] = useState(false)
 
-  useInterval(
-    () => {
-      setCollapse(true)
-    },
-    !visible && !collapse ? 250 : null,
-  )
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>
+
+    if (visible) {
+      setCollapse(false)
+    } else {
+      timeout = setTimeout(() => {
+        setCollapse(true)
+      }, hideDelay)
+    }
+
+    return () => {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+    }
+  }, [hideDelay, visible])
 
   if (collapse) {
     return null

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,39 @@
+import { cn } from '@/lib/utils'
+import { PropsWithChildren, useState } from 'react'
+import { useInterval } from 'usehooks-ts'
+
+export interface ToastProps {
+  visible?: boolean
+  className?: string
+}
+
+export function Toast({
+  visible,
+  className,
+  children,
+}: PropsWithChildren<ToastProps>) {
+  const [collapse, setCollapse] = useState(false)
+
+  useInterval(
+    () => {
+      setCollapse(true)
+    },
+    !visible && !collapse ? 250 : null,
+  )
+
+  if (collapse) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        'bg-neutral-200/20 dark:bg-neutral-800/20 backdrop-blur-xl border border-border rounded-md pl-3 pr-1.5 py-2 motion-safe:transition-opacity text-sm flex items-center justify-between gap-12 shadow-xs min-h-12.5 font-medium',
+        !visible ? 'pointer-events-none opacity-0' : 'opacity-100',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/utils'
 import { PropsWithChildren, useEffect, useState } from 'react'
+import { useDebounceValue } from 'usehooks-ts'
 
 export interface ToastProps {
   visible?: boolean
@@ -14,6 +15,8 @@ export function Toast({
   children,
 }: PropsWithChildren<ToastProps>) {
   const [collapse, setCollapse] = useState(false)
+
+  const [preventRender] = useDebounceValue(!visible, 250)
 
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout>
@@ -33,7 +36,7 @@ export function Toast({
     }
   }, [hideDelay, visible])
 
-  if (collapse) {
+  if (preventRender) {
     return null
   }
 
@@ -41,7 +44,7 @@ export function Toast({
     <div
       className={cn(
         'bg-neutral-200/20 dark:bg-neutral-800/20 backdrop-blur-xl border border-border rounded-md pl-3 pr-1.5 py-2 motion-safe:transition-opacity text-sm flex items-center justify-between gap-12 shadow-xs min-h-12.5',
-        !visible ? 'pointer-events-none opacity-0' : 'opacity-100',
+        collapse ? 'pointer-events-none opacity-0' : 'opacity-100',
         className,
       )}
     >

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -21,6 +21,7 @@ import { useCreateFolder } from '@/lib/files/useCreateFolder'
 import { useCurrentFolderPath } from '@/lib/files/useCurrentFolderPath'
 import { useFilesAndFolders } from '@/lib/files/useFilesAndFolders'
 import { logEvent } from '@/lib/logging/useLogger'
+import { ModelDownloadToast } from '@/lib/modelDownload/ModelDownloadToast'
 import { AppLayoutContextProps } from '@/lib/types'
 import { UpdateToast } from '@/lib/updater/UpdateToast'
 import { useToast } from '@/lib/useToast'
@@ -232,7 +233,10 @@ export function AppLayout() {
     <BaseLayout>
       <SearchDialog open={searchOpen} onOpenChange={setSearchOpen} />
 
-      <UpdateToast />
+      <div className="flex flex-col gap-2 absolute bottom-5 left-5 z-[200] w-sm">
+        <ModelDownloadToast />
+        <UpdateToast />
+      </div>
 
       <DndContext
         sensors={[mouseSensor]}

--- a/src/components/layout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout.tsx
@@ -7,7 +7,6 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { LocationHistoryProvider } from '@/lib/locationHistory/LocationHistoryProvider'
-import { ModelDownloadProvider } from '@/lib/modelDownload/ModelDownloadProvider'
 import { useInvalidateQueriesOnWindowFocus } from '@/lib/useInvalidateQueriesOnWindowFocus'
 import { useMenuBar } from '@/lib/useMenuBar'
 import { cn } from '@/lib/utils'
@@ -60,13 +59,11 @@ export function BaseLayout({ children }: PropsWithChildren) {
         </DialogContent>
       </Dialog>
 
-      <ModelDownloadProvider>
-        <LocationHistoryProvider>
-          <BaseLayoutContent onOpenAbout={() => setAboutDialogOpen(true)}>
-            {children}
-          </BaseLayoutContent>
-        </LocationHistoryProvider>
-      </ModelDownloadProvider>
+      <LocationHistoryProvider>
+        <BaseLayoutContent onOpenAbout={() => setAboutDialogOpen(true)}>
+          {children}
+        </BaseLayoutContent>
+      </LocationHistoryProvider>
     </>
   )
 }

--- a/src/components/layout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { LocationHistoryProvider } from '@/lib/locationHistory/LocationHistoryProvider'
+import { ModelDownloadProvider } from '@/lib/modelDownload/ModelDownloadProvider'
 import { useInvalidateQueriesOnWindowFocus } from '@/lib/useInvalidateQueriesOnWindowFocus'
 import { useMenuBar } from '@/lib/useMenuBar'
 import { cn } from '@/lib/utils'
@@ -59,11 +60,13 @@ export function BaseLayout({ children }: PropsWithChildren) {
         </DialogContent>
       </Dialog>
 
-      <LocationHistoryProvider>
-        <BaseLayoutContent onOpenAbout={() => setAboutDialogOpen(true)}>
-          {children}
-        </BaseLayoutContent>
-      </LocationHistoryProvider>
+      <ModelDownloadProvider>
+        <LocationHistoryProvider>
+          <BaseLayoutContent onOpenAbout={() => setAboutDialogOpen(true)}>
+            {children}
+          </BaseLayoutContent>
+        </LocationHistoryProvider>
+      </ModelDownloadProvider>
     </>
   )
 }

--- a/src/components/ollama/AIAssistantConfigPanel.tsx
+++ b/src/components/ollama/AIAssistantConfigPanel.tsx
@@ -38,6 +38,7 @@ import {
   RECOMMENDED_AUTOCOMPLETION_MODEL,
   RECOMMENDED_WRITING_IMPROVEMENTS_MODEL,
 } from '@/lib/constants'
+import { ModelDownloadPanel } from '@/components/ollama/ModelDownloadPanel'
 
 export interface AIAssistantConfigPanelProps {
   onSubmit: (values: AssistantSettingsFormValues) => void
@@ -164,14 +165,14 @@ export function AIAssistantConfigPanel({
             <FieldContent>
               <FieldLabel className="text-base">AI Models</FieldLabel>
               <FieldDescription>
-                Download models from Ollama first, then select them here. See{' '}
+                For details on downloading additional models, see the{' '}
                 <Anchor
                   href="https://docs.ollama.com/cli#download-a-model"
                   className="text-blue-500 !underline-offset-2 dark:text-blue-400"
                 >
-                  the quickstart guide
-                </Anchor>{' '}
-                for instructions.
+                  Ollama CLI reference
+                </Anchor>
+                .
               </FieldDescription>
             </FieldContent>
 
@@ -187,53 +188,59 @@ export function AIAssistantConfigPanel({
             </Button>
           </Field>
 
-          <ModelSelectorField
-            control={form.control}
-            name="completionModel"
-            label="Autocomplete"
-            ariaLabel="Model used by the autocomplete feature"
-            disabled={
-              !watchAiAssistantEnabled ||
-              !models ||
-              models.length === 0 ||
-              (!isConnected && !connectionLoading)
-            }
-            models={models}
-            modelsLoading={modelsLoading}
-            modelsError={modelsError}
-            onCopyCommand={() =>
-              handleCopyOllamaPullCommand(
-                RECOMMENDED_AUTOCOMPLETION_MODEL.name,
-                toast,
-              )
-            }
-            disableAnimations={disableAnimations}
-            recommendedModel={RECOMMENDED_AUTOCOMPLETION_MODEL.name}
-          />
+          {!models || models.length === 0 ? (
+            <ModelDownloadPanel ollamaUrl={targetOllamaUrl} />
+          ) : (
+            <>
+              <ModelSelectorField
+                control={form.control}
+                name="completionModel"
+                label="Autocomplete"
+                ariaLabel="Model used by the autocomplete feature"
+                disabled={
+                  !watchAiAssistantEnabled ||
+                  !models ||
+                  models.length === 0 ||
+                  (!isConnected && !connectionLoading)
+                }
+                models={models}
+                modelsLoading={modelsLoading}
+                modelsError={modelsError}
+                onCopyCommand={() =>
+                  handleCopyOllamaPullCommand(
+                    RECOMMENDED_AUTOCOMPLETION_MODEL.name,
+                    toast,
+                  )
+                }
+                disableAnimations={disableAnimations}
+                recommendedModel={RECOMMENDED_AUTOCOMPLETION_MODEL.name}
+              />
 
-          <ModelSelectorField
-            control={form.control}
-            name="improvementModel"
-            label="Writing Improvements"
-            ariaLabel="Model used by the writing improvement feature"
-            disabled={
-              !watchAiAssistantEnabled ||
-              !models ||
-              models.length === 0 ||
-              (!isConnected && !connectionLoading)
-            }
-            models={models}
-            modelsLoading={modelsLoading}
-            modelsError={modelsError}
-            onCopyCommand={() =>
-              handleCopyOllamaPullCommand(
-                RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name,
-                toast,
-              )
-            }
-            disableAnimations={disableAnimations}
-            recommendedModel={RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name}
-          />
+              <ModelSelectorField
+                control={form.control}
+                name="improvementModel"
+                label="Writing Improvements"
+                ariaLabel="Model used by the writing improvement feature"
+                disabled={
+                  !watchAiAssistantEnabled ||
+                  !models ||
+                  models.length === 0 ||
+                  (!isConnected && !connectionLoading)
+                }
+                models={models}
+                modelsLoading={modelsLoading}
+                modelsError={modelsError}
+                onCopyCommand={() =>
+                  handleCopyOllamaPullCommand(
+                    RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name,
+                    toast,
+                  )
+                }
+                disableAnimations={disableAnimations}
+                recommendedModel={RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name}
+              />
+            </>
+          )}
 
           <Collapsible
             id="advanced-options"

--- a/src/components/ollama/AIAssistantConfigPanel.tsx
+++ b/src/components/ollama/AIAssistantConfigPanel.tsx
@@ -166,12 +166,12 @@ export function AIAssistantConfigPanel({
               <FieldDescription>
                 Download models from Ollama first, then select them here. See{' '}
                 <Anchor
-                  href="https://docs.ollama.com/quickstart"
+                  href="https://docs.ollama.com/cli#download-a-model"
                   className="text-blue-500 !underline-offset-2 dark:text-blue-400"
                 >
                   the quickstart guide
                 </Anchor>{' '}
-                for setup instructions.
+                for instructions.
               </FieldDescription>
             </FieldContent>
 

--- a/src/components/ollama/AIAssistantConfigPanel.tsx
+++ b/src/components/ollama/AIAssistantConfigPanel.tsx
@@ -268,7 +268,7 @@ export function AIAssistantConfigPanel({
 
             <CollapsibleContent
               className={cn(
-                'p-3 rounded-md bg-secondary dark:bg-secondary/40 mt-3 border border-input/50',
+                'p-3 rounded-md bg-secondary/40 dark:bg-secondary/40 mt-3 border border-border dark:border-input/50',
                 placement === 'onboarding' &&
                   'bg-card/90 dark:bg-input/30 border-input',
               )}

--- a/src/components/ollama/ModelDownloadPanel.tsx
+++ b/src/components/ollama/ModelDownloadPanel.tsx
@@ -11,6 +11,7 @@ import {
   RECOMMENDED_WRITING_IMPROVEMENTS_MODEL,
 } from '@/lib/constants'
 import { useModelDownloadContext } from '@/lib/modelDownload/useModelDownloadContext'
+import { cn } from '@/lib/utils'
 import { Info } from 'lucide-react'
 import { PropsWithChildren } from 'react'
 
@@ -18,9 +19,17 @@ interface ModelDownloadPanelProps {
   ollamaUrl?: string
 }
 
-function Wrapper({ children }: PropsWithChildren) {
+function Wrapper({
+  children,
+  className,
+}: PropsWithChildren<{ className?: string }>) {
   return (
-    <div className="-mt-3 p-4 border border-input/50 rounded-md flex flex-col justify-center items-start gap-3 text-sm bg-secondary dark:bg-secondary/40 text-muted-foreground">
+    <div
+      className={cn(
+        '-mt-3 p-4 border border-border dark:border-input/50 rounded-md flex flex-col justify-center items-start gap-3 text-sm bg-secondary/40 dark:bg-secondary/40 text-muted-foreground',
+        className,
+      )}
+    >
       {children}
     </div>
   )
@@ -36,8 +45,12 @@ export function ModelDownloadPanel({ ollamaUrl }: ModelDownloadPanelProps) {
 
   if (downloading) {
     return (
-      <Wrapper>
-        <ActivityIndicator>Downloading models...</ActivityIndicator>
+      <Wrapper className="flex-row justify-start items-center gap-1.5">
+        <ActivityIndicator className="text-xs" srOnly>
+          Downloading models...
+        </ActivityIndicator>
+        Download progress appears in the bottom left corner. You&apos;re free to
+        navigate other pages.
       </Wrapper>
     )
   }
@@ -51,6 +64,7 @@ export function ModelDownloadPanel({ ollamaUrl }: ModelDownloadPanelProps) {
           disabled={!ollamaUrl}
           onClick={() => startDownload(ollamaUrl!)}
           size="sm"
+          type="button"
         >
           Install Models
         </Button>
@@ -62,11 +76,11 @@ export function ModelDownloadPanel({ ollamaUrl }: ModelDownloadPanelProps) {
 
           <TooltipContent className="leading-normal">
             Pressing the button will download{' '}
-            <InlineCode className="text-xs px-0">
+            <InlineCode className="text-xs px-0 bg-transparent">
               {RECOMMENDED_AUTOCOMPLETION_MODEL.name}
             </InlineCode>{' '}
             and{' '}
-            <InlineCode className="text-xs px-0">
+            <InlineCode className="text-xs px-0 bg-transparent">
               {RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name}
             </InlineCode>
             , which require approximately a total of{' '}

--- a/src/components/ollama/ModelDownloadPanel.tsx
+++ b/src/components/ollama/ModelDownloadPanel.tsx
@@ -1,0 +1,79 @@
+import { ActivityIndicator } from '@/components/ActivityIndicator'
+import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { InlineCode } from '@/components/ui/typography'
+import {
+  RECOMMENDED_AUTOCOMPLETION_MODEL,
+  RECOMMENDED_WRITING_IMPROVEMENTS_MODEL,
+} from '@/lib/constants'
+import { useModelDownloadContext } from '@/lib/modelDownload/useModelDownloadContext'
+import { Info } from 'lucide-react'
+import { PropsWithChildren } from 'react'
+
+interface ModelDownloadPanelProps {
+  ollamaUrl?: string
+}
+
+function Wrapper({ children }: PropsWithChildren) {
+  return (
+    <div className="-mt-3 p-4 border border-input/50 rounded-md flex flex-col justify-center items-start gap-3 text-sm bg-secondary dark:bg-secondary/40 text-muted-foreground">
+      {children}
+    </div>
+  )
+}
+
+export function ModelDownloadPanel({ ollamaUrl }: ModelDownloadPanelProps) {
+  const { autocompletionModel, writingImprovementsModel, startDownload } =
+    useModelDownloadContext()
+
+  const downloading =
+    autocompletionModel.modelStatus === 'pending' ||
+    writingImprovementsModel.modelStatus === 'pending'
+
+  if (downloading) {
+    return (
+      <Wrapper>
+        <ActivityIndicator>Downloading models...</ActivityIndicator>
+      </Wrapper>
+    )
+  }
+
+  return (
+    <Wrapper>
+      <p>No AI models found. Install them using the button below.</p>
+
+      <div className="flex items-center gap-2">
+        <Button
+          disabled={!ollamaUrl}
+          onClick={() => startDownload(ollamaUrl!)}
+          size="sm"
+        >
+          Install Models
+        </Button>
+
+        <Tooltip>
+          <TooltipTrigger>
+            <Info className="size-4" />
+          </TooltipTrigger>
+
+          <TooltipContent className="leading-normal">
+            Pressing the button will download{' '}
+            <InlineCode className="text-xs px-0">
+              {RECOMMENDED_AUTOCOMPLETION_MODEL.name}
+            </InlineCode>{' '}
+            and{' '}
+            <InlineCode className="text-xs px-0">
+              {RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name}
+            </InlineCode>
+            , which require approximately a total of{' '}
+            <strong className="font-medium">5.5 GB</strong> of disk space.
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </Wrapper>
+  )
+}

--- a/src/components/ollama/ModelDownloadPanel.tsx
+++ b/src/components/ollama/ModelDownloadPanel.tsx
@@ -49,8 +49,9 @@ export function ModelDownloadPanel({ ollamaUrl }: ModelDownloadPanelProps) {
         <ActivityIndicator className="text-xs" srOnly>
           Downloading models...
         </ActivityIndicator>
-        Download progress appears in the bottom left corner. You&apos;re free to
-        navigate other pages.
+        You&apos;ll see download progress in the bottom left corner.
+        Installation typically takes 3-5 minutes depending on your network
+        speed—feel free to navigate elsewhere while it runs.
       </Wrapper>
     )
   }

--- a/src/components/ollama/ModelDownloadPanel.tsx
+++ b/src/components/ollama/ModelDownloadPanel.tsx
@@ -75,13 +75,13 @@ export function ModelDownloadPanel({ ollamaUrl }: ModelDownloadPanelProps) {
             <Info className="size-4" />
           </TooltipTrigger>
 
-          <TooltipContent className="leading-normal">
+          <TooltipContent side="right" className="leading-normal text-sm">
             Pressing the button will download{' '}
-            <InlineCode className="text-xs px-0 bg-transparent">
+            <InlineCode className="text-sm px-0 bg-transparent">
               {RECOMMENDED_AUTOCOMPLETION_MODEL.name}
             </InlineCode>{' '}
             and{' '}
-            <InlineCode className="text-xs px-0 bg-transparent">
+            <InlineCode className="text-sm px-0 bg-transparent">
               {RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name}
             </InlineCode>
             , which require approximately a total of{' '}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -17,12 +17,12 @@ export const TOGGLE_PREVIEW_EVENT = 'toggle-preview'
 
 // AI assistant constants
 export const RECOMMENDED_AUTOCOMPLETION_MODEL = {
-  name: 'qwen2.5-coder:0.5b-base',
+  name: 'granite-embedding:30m',
   url: 'https://ollama.com/library/qwen2.5-coder:3b-base',
 }
 
 export const RECOMMENDED_WRITING_IMPROVEMENTS_MODEL = {
-  name: 'gemma3:270m',
+  name: 'smollm:135m',
   url: 'https://ollama.com/library/gemma3:latest',
 }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -17,12 +17,12 @@ export const TOGGLE_PREVIEW_EVENT = 'toggle-preview'
 
 // AI assistant constants
 export const RECOMMENDED_AUTOCOMPLETION_MODEL = {
-  name: 'granite-embedding:30m',
+  name: 'qwen2.5-coder:3b-base',
   url: 'https://ollama.com/library/qwen2.5-coder:3b-base',
 }
 
 export const RECOMMENDED_WRITING_IMPROVEMENTS_MODEL = {
-  name: 'smollm:135m',
+  name: 'gemma3:latest',
   url: 'https://ollama.com/library/gemma3:latest',
 }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -17,12 +17,12 @@ export const TOGGLE_PREVIEW_EVENT = 'toggle-preview'
 
 // AI assistant constants
 export const RECOMMENDED_AUTOCOMPLETION_MODEL = {
-  name: 'qwen2.5-coder:3b-base',
+  name: 'qwen2.5-coder:0.5b-base',
   url: 'https://ollama.com/library/qwen2.5-coder:3b-base',
 }
 
 export const RECOMMENDED_WRITING_IMPROVEMENTS_MODEL = {
-  name: 'gemma3:latest',
+  name: 'gemma3:270m',
   url: 'https://ollama.com/library/gemma3:latest',
 }
 

--- a/src/lib/logging/useLogger.ts
+++ b/src/lib/logging/useLogger.ts
@@ -12,6 +12,11 @@ export async function logEvent(
   context?: LogContext,
 ) {
   try {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.debug(level, category, message, context)
+    }
+
     await invoke('log_event', {
       level,
       category,

--- a/src/lib/modelDownload/ModelDownloadContext.ts
+++ b/src/lib/modelDownload/ModelDownloadContext.ts
@@ -2,21 +2,25 @@ import { usePullModelWithStatus } from '@/lib/modelDownload/usePullModelWithStat
 import { createContext } from 'react'
 
 export interface ModelDownloadContextProps {
+  downloadStatus: 'idle' | 'pending' | 'success' | 'error'
   autocompletionModel: ReturnType<typeof usePullModelWithStatus>
   writingImprovementsModel: ReturnType<typeof usePullModelWithStatus>
   startDownload: (ollamaUrl: string) => Promise<void>
 }
 
 export const ModelDownloadContext = createContext<ModelDownloadContextProps>({
+  downloadStatus: 'idle',
   autocompletionModel: {
     modelError: null,
     modelProgress: 0,
     modelStatus: 'idle',
+    resetState: () => {},
   },
   writingImprovementsModel: {
     modelError: null,
     modelProgress: 0,
     modelStatus: 'idle',
+    resetState: () => {},
   },
   startDownload: () => {
     return Promise.reject('Not Implemented')

--- a/src/lib/modelDownload/ModelDownloadContext.ts
+++ b/src/lib/modelDownload/ModelDownloadContext.ts
@@ -1,0 +1,24 @@
+import { usePullModelWithStatus } from '@/lib/modelDownload/usePullModelWithStatus'
+import { createContext } from 'react'
+
+export interface ModelDownloadContextProps {
+  autocompletionModel: ReturnType<typeof usePullModelWithStatus>
+  writingImprovementsModel: ReturnType<typeof usePullModelWithStatus>
+  startDownload: (ollamaUrl: string) => Promise<void>
+}
+
+export const ModelDownloadContext = createContext<ModelDownloadContextProps>({
+  autocompletionModel: {
+    modelError: null,
+    modelProgress: 0,
+    modelStatus: 'idle',
+  },
+  writingImprovementsModel: {
+    modelError: null,
+    modelProgress: 0,
+    modelStatus: 'idle',
+  },
+  startDownload: () => {
+    return Promise.reject('Not Implemented')
+  },
+})

--- a/src/lib/modelDownload/ModelDownloadProvider.tsx
+++ b/src/lib/modelDownload/ModelDownloadProvider.tsx
@@ -1,0 +1,51 @@
+import {
+  RECOMMENDED_AUTOCOMPLETION_MODEL,
+  RECOMMENDED_WRITING_IMPROVEMENTS_MODEL,
+} from '@/lib/constants'
+import { ModelDownloadContext } from '@/lib/modelDownload/ModelDownloadContext'
+import { usePullModelWithStatus } from '@/lib/modelDownload/usePullModelWithStatus'
+import { DEFAULT_OLLAMA_URL } from '@/lib/ollama/ollama'
+import { testOllamaConnection } from '@/lib/ollama/useOllamaConnection'
+import { PropsWithChildren, useState } from 'react'
+
+export function ModelDownloadProvider({ children }: PropsWithChildren) {
+  const [ollamaUrl, setOllamaUrl] = useState(DEFAULT_OLLAMA_URL)
+  const [downloadEnabled, setDownloadEnabled] = useState(false)
+
+  const autocompletionModel = usePullModelWithStatus({
+    disabled: !downloadEnabled,
+    model: RECOMMENDED_AUTOCOMPLETION_MODEL.name,
+    connected: true,
+    ollamaUrl,
+  })
+
+  const writingImprovementsModel = usePullModelWithStatus({
+    disabled: !downloadEnabled,
+    model: RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name,
+    connected: true,
+    ollamaUrl,
+  })
+
+  async function handleStartDownload(externalOllamaUrl: string) {
+    const isConnected = await testOllamaConnection(externalOllamaUrl)
+
+    if (!isConnected) {
+      throw new Error('Failed to connect to Ollama.')
+    }
+
+    setDownloadEnabled(true)
+    setOllamaUrl(externalOllamaUrl)
+  }
+
+  return (
+    <ModelDownloadContext.Provider
+      value={{
+        autocompletionModel,
+        writingImprovementsModel,
+        startDownload: handleStartDownload,
+      }}
+    >
+      {children}
+    </ModelDownloadContext.Provider>
+  )
+}

--- a/src/lib/modelDownload/ModelDownloadProvider.tsx
+++ b/src/lib/modelDownload/ModelDownloadProvider.tsx
@@ -3,10 +3,12 @@ import {
   RECOMMENDED_WRITING_IMPROVEMENTS_MODEL,
 } from '@/lib/constants'
 import { useUpdateConfig } from '@/lib/db/useUpdateConfig'
+import { logEvent } from '@/lib/logging/useLogger'
 import { ModelDownloadContext } from '@/lib/modelDownload/ModelDownloadContext'
 import { usePullModelWithStatus } from '@/lib/modelDownload/usePullModelWithStatus'
 import { DEFAULT_OLLAMA_URL } from '@/lib/ollama/ollama'
 import { testOllamaConnection } from '@/lib/ollama/useOllamaConnection'
+import { useOllamaModels } from '@/lib/ollama/useOllamaModels'
 import { PropsWithChildren, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -15,12 +17,14 @@ export function ModelDownloadProvider({ children }: PropsWithChildren) {
   const [ollamaUrl, setOllamaUrl] = useState(DEFAULT_OLLAMA_URL)
   const [downloadEnabled, setDownloadEnabled] = useState(false)
   const { mutateAsync: updateConfig } = useUpdateConfig()
+  const { refetch: refetchModels } = useOllamaModels(ollamaUrl)
 
   const autocompletionModel = usePullModelWithStatus({
     disabled: !downloadEnabled,
     model: RECOMMENDED_AUTOCOMPLETION_MODEL.name,
     connected: true,
     ollamaUrl,
+    variant: 'autocompletion',
   })
 
   const writingImprovementsModel = usePullModelWithStatus({
@@ -28,9 +32,8 @@ export function ModelDownloadProvider({ children }: PropsWithChildren) {
     model: RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name,
     connected: true,
     ollamaUrl,
+    variant: 'writing-improvements',
   })
-
-  // TODO: SOMEHOW FORCE RESET ON THE PULL STATUS BECAUSE DELETING THE MODELS AND FOCUSING THE WINDOW DOESN'T PERFORM A FULL RESET
 
   const bothSucceeded =
     autocompletionModel.modelStatus === 'success' &&
@@ -52,17 +55,26 @@ export function ModelDownloadProvider({ children }: PropsWithChildren) {
             key: 'improvement_model',
             value: RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name || '',
           }),
+          refetchModels(),
         ])
         updatedConfigRef.current = true
         setDownloadEnabled(false)
         toast.success('AI models successfully downloaded.')
-      } catch {
-        toast.error('Failed to update config.')
+      } catch (error) {
+        logEvent(
+          'ERROR',
+          'model-download',
+          `Failed to update config: ${(error as Error).message}`,
+          { stack: (error as Error).stack || null },
+        )
+        toast.error(
+          'Failed to update config. Configure models manually on the Preferences page.',
+        )
       }
     }
 
     updateSelectedModels()
-  }, [bothSucceeded, downloadEnabled, updateConfig])
+  }, [bothSucceeded, downloadEnabled, refetchModels, updateConfig])
 
   async function handleStartDownload(externalOllamaUrl: string) {
     const isConnected = await testOllamaConnection(externalOllamaUrl)

--- a/src/lib/modelDownload/ModelDownloadProvider.tsx
+++ b/src/lib/modelDownload/ModelDownloadProvider.tsx
@@ -2,15 +2,19 @@ import {
   RECOMMENDED_AUTOCOMPLETION_MODEL,
   RECOMMENDED_WRITING_IMPROVEMENTS_MODEL,
 } from '@/lib/constants'
+import { useUpdateConfig } from '@/lib/db/useUpdateConfig'
 import { ModelDownloadContext } from '@/lib/modelDownload/ModelDownloadContext'
 import { usePullModelWithStatus } from '@/lib/modelDownload/usePullModelWithStatus'
 import { DEFAULT_OLLAMA_URL } from '@/lib/ollama/ollama'
 import { testOllamaConnection } from '@/lib/ollama/useOllamaConnection'
-import { PropsWithChildren, useState } from 'react'
+import { PropsWithChildren, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
 
 export function ModelDownloadProvider({ children }: PropsWithChildren) {
+  const updatedConfigRef = useRef<boolean>(false)
   const [ollamaUrl, setOllamaUrl] = useState(DEFAULT_OLLAMA_URL)
   const [downloadEnabled, setDownloadEnabled] = useState(false)
+  const { mutateAsync: updateConfig } = useUpdateConfig()
 
   const autocompletionModel = usePullModelWithStatus({
     disabled: !downloadEnabled,
@@ -25,6 +29,40 @@ export function ModelDownloadProvider({ children }: PropsWithChildren) {
     connected: true,
     ollamaUrl,
   })
+
+  // TODO: SOMEHOW FORCE RESET ON THE PULL STATUS BECAUSE DELETING THE MODELS AND FOCUSING THE WINDOW DOESN'T PERFORM A FULL RESET
+
+  const bothSucceeded =
+    autocompletionModel.modelStatus === 'success' &&
+    writingImprovementsModel.modelStatus === 'success'
+
+  useEffect(() => {
+    if (updatedConfigRef.current || !bothSucceeded || !downloadEnabled) {
+      return
+    }
+
+    async function updateSelectedModels() {
+      try {
+        await Promise.all([
+          updateConfig({
+            key: 'completion_model',
+            value: RECOMMENDED_AUTOCOMPLETION_MODEL.name || '',
+          }),
+          updateConfig({
+            key: 'improvement_model',
+            value: RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name || '',
+          }),
+        ])
+        updatedConfigRef.current = true
+        setDownloadEnabled(false)
+        toast.success('AI models successfully downloaded.')
+      } catch {
+        toast.error('Failed to update config.')
+      }
+    }
+
+    updateSelectedModels()
+  }, [bothSucceeded, downloadEnabled, updateConfig])
 
   async function handleStartDownload(externalOllamaUrl: string) {
     const isConnected = await testOllamaConnection(externalOllamaUrl)

--- a/src/lib/modelDownload/ModelDownloadToast.tsx
+++ b/src/lib/modelDownload/ModelDownloadToast.tsx
@@ -1,36 +1,37 @@
 import { Toast } from '@/components/Toast'
-import { Progress } from '@/components/ui/progress'
 import { H3 } from '@/components/ui/typography'
 import { useModelDownloadContext } from '@/lib/modelDownload/useModelDownloadContext'
+import { ModelProgress } from '@/lib/updater/ModelProgress'
+import { useState } from 'react'
 
 export function ModelDownloadToast() {
   const { autocompletionModel, writingImprovementsModel } =
     useModelDownloadContext()
+  // TODO: Show only if model downloads are in progress
+  const [visible] = useState(true)
 
   return (
     <Toast
-      visible
+      visible={visible}
       className="pl-[unset] pr-[unset] px-3! flex flex-col gap-2 w-full"
     >
-      <H3 className="text-sm self-start my-0 text-muted-foreground sr-only">
-        Model Download Status
+      <H3 className="text-sm self-start my-0 text-muted-foreground font-normal sr-only">
+        Downloading AI models
       </H3>
 
-      <div className="grid grid-cols-2 items-center w-full">
-        <span className="whitespace-nowrap">Autocompletion</span>
+      <ModelProgress
+        name="Autocompletion"
+        status={autocompletionModel.modelStatus}
+        progress={autocompletionModel.modelProgress}
+        error={autocompletionModel.modelError}
+      />
 
-        <span className="shrink-0 grow">
-          <Progress value={autocompletionModel.modelProgress} max={100} />
-        </span>
-      </div>
-
-      <div className="grid grid-cols-2 items-center w-full">
-        <span className="whitespace-nowrap">Writing Improvements</span>
-
-        <span className="shrink-0 grow">
-          <Progress value={writingImprovementsModel.modelProgress} max={100} />
-        </span>
-      </div>
+      <ModelProgress
+        name="Writing Improvements"
+        status={writingImprovementsModel.modelStatus}
+        progress={writingImprovementsModel.modelProgress}
+        error={writingImprovementsModel.modelError}
+      />
     </Toast>
   )
 }

--- a/src/lib/modelDownload/ModelDownloadToast.tsx
+++ b/src/lib/modelDownload/ModelDownloadToast.tsx
@@ -3,18 +3,42 @@ import { Separator } from '@/components/ui/separator'
 import { H3 } from '@/components/ui/typography'
 import { useModelDownloadContext } from '@/lib/modelDownload/useModelDownloadContext'
 import { ModelProgress } from '@/lib/updater/ModelProgress'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export function ModelDownloadToast() {
   const { autocompletionModel, writingImprovementsModel } =
     useModelDownloadContext()
-  // TODO: Show only if model downloads are in progress
-  const [visible] = useState(true)
+  const [visible, setVisible] = useState(false)
+
+  const anyPending =
+    autocompletionModel.modelStatus === 'pending' ||
+    writingImprovementsModel.modelStatus === 'pending'
+
+  const bothSucceeded =
+    autocompletionModel.modelStatus === 'success' &&
+    writingImprovementsModel.modelStatus === 'success'
+
+  useEffect(() => {
+    if (!anyPending || visible) {
+      return
+    }
+
+    setVisible(true)
+  }, [anyPending, visible])
+
+  useEffect(() => {
+    if (!bothSucceeded || !visible) {
+      return
+    }
+
+    setVisible(false)
+  }, [bothSucceeded, visible])
 
   return (
     <Toast
       visible={visible}
       className="pl-[unset] pr-[unset] px-3! flex flex-col gap-2 w-full"
+      hideDelay={3000}
     >
       <H3 className="text-sm self-start my-0 text-muted-foreground font-normal sr-only">
         Downloading AI models

--- a/src/lib/modelDownload/ModelDownloadToast.tsx
+++ b/src/lib/modelDownload/ModelDownloadToast.tsx
@@ -38,7 +38,6 @@ export function ModelDownloadToast() {
     <Toast
       visible={visible}
       className="pl-[unset] pr-[unset] px-3! flex flex-col gap-2 w-full"
-      hideDelay={3000}
     >
       <H3 className="text-sm self-start my-0 text-muted-foreground font-normal sr-only">
         Downloading AI models

--- a/src/lib/modelDownload/ModelDownloadToast.tsx
+++ b/src/lib/modelDownload/ModelDownloadToast.tsx
@@ -1,4 +1,5 @@
 import { Toast } from '@/components/Toast'
+import { Separator } from '@/components/ui/separator'
 import { H3 } from '@/components/ui/typography'
 import { useModelDownloadContext } from '@/lib/modelDownload/useModelDownloadContext'
 import { ModelProgress } from '@/lib/updater/ModelProgress'
@@ -25,6 +26,8 @@ export function ModelDownloadToast() {
         progress={autocompletionModel.modelProgress}
         error={autocompletionModel.modelError}
       />
+
+      <Separator />
 
       <ModelProgress
         name="Writing Improvements"

--- a/src/lib/modelDownload/ModelDownloadToast.tsx
+++ b/src/lib/modelDownload/ModelDownloadToast.tsx
@@ -1,0 +1,36 @@
+import { Toast } from '@/components/Toast'
+import { Progress } from '@/components/ui/progress'
+import { H3 } from '@/components/ui/typography'
+import { useModelDownloadContext } from '@/lib/modelDownload/useModelDownloadContext'
+
+export function ModelDownloadToast() {
+  const { autocompletionModel, writingImprovementsModel } =
+    useModelDownloadContext()
+
+  return (
+    <Toast
+      visible
+      className="pl-[unset] pr-[unset] px-3! flex flex-col gap-2 w-full"
+    >
+      <H3 className="text-sm self-start my-0 text-muted-foreground sr-only">
+        Model Download Status
+      </H3>
+
+      <div className="grid grid-cols-2 items-center w-full">
+        <span className="whitespace-nowrap">Autocompletion</span>
+
+        <span className="shrink-0 grow">
+          <Progress value={autocompletionModel.modelProgress} max={100} />
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 items-center w-full">
+        <span className="whitespace-nowrap">Writing Improvements</span>
+
+        <span className="shrink-0 grow">
+          <Progress value={writingImprovementsModel.modelProgress} max={100} />
+        </span>
+      </div>
+    </Toast>
+  )
+}

--- a/src/lib/modelDownload/useModelDownloadContext.ts
+++ b/src/lib/modelDownload/useModelDownloadContext.ts
@@ -1,0 +1,14 @@
+import { ModelDownloadContext } from '@/lib/modelDownload/ModelDownloadContext'
+import { useContext } from 'react'
+
+export function useModelDownloadContext() {
+  const context = useContext(ModelDownloadContext)
+
+  if (!context) {
+    throw new Error(
+      'useModelDownloadContext must be used in a ModelDownloadContext',
+    )
+  }
+
+  return context
+}

--- a/src/lib/modelDownload/usePullModelWithStatus.ts
+++ b/src/lib/modelDownload/usePullModelWithStatus.ts
@@ -8,6 +8,7 @@ export interface UsePullModelWithStatusProps {
   disabled?: boolean
   connected?: boolean
   ollamaUrl?: string
+  variant: 'autocompletion' | 'writing-improvements'
 }
 
 export function usePullModelWithStatus({
@@ -15,6 +16,7 @@ export function usePullModelWithStatus({
   disabled,
   connected,
   ollamaUrl: externalOllamaUrl,
+  variant,
 }: UsePullModelWithStatusProps) {
   const { ollamaUrl } = useOllamaConfig()
 
@@ -23,6 +25,7 @@ export function usePullModelWithStatus({
       serverUrl: externalOllamaUrl || ollamaUrl,
       model,
       disabled: !connected,
+      variant,
     })
 
   // We disable pulling the model if:
@@ -109,6 +112,18 @@ export function usePullModelWithStatus({
     setModelProgress(100)
     setModelStatus('success')
   }, [modelDetails, modelDetailsStatus])
+
+  useEffect(() => {
+    // TODO: Reset all local state when model status is missing
+    if (
+      modelDetails &&
+      'status' in modelDetails &&
+      modelDetails.status === 'missing'
+    ) {
+      setModelProgress(0)
+      setModelStatus('idle')
+    }
+  }, [modelDetails])
 
   return {
     modelStatus:

--- a/src/lib/modelDownload/usePullModelWithStatus.ts
+++ b/src/lib/modelDownload/usePullModelWithStatus.ts
@@ -7,18 +7,20 @@ export interface UsePullModelWithStatusProps {
   model?: string
   disabled?: boolean
   connected?: boolean
+  ollamaUrl?: string
 }
 
 export function usePullModelWithStatus({
   model,
   disabled,
   connected,
+  ollamaUrl: externalOllamaUrl,
 }: UsePullModelWithStatusProps) {
   const { ollamaUrl } = useOllamaConfig()
 
   const { data: modelDetails, status: modelDetailsStatus } =
     useOllamaModelDetails({
-      serverUrl: ollamaUrl,
+      serverUrl: externalOllamaUrl || ollamaUrl,
       model,
       disabled: !connected,
     })
@@ -36,7 +38,7 @@ export function usePullModelWithStatus({
   const [modelProgress, setModelProgress] = useState(0)
 
   const { data, error, status } = usePullOllamaModel({
-    serverUrl: ollamaUrl,
+    serverUrl: externalOllamaUrl || ollamaUrl,
     model,
     disabled: isPullDisabled,
   })

--- a/src/lib/ollama/useOllamaModelDetails.ts
+++ b/src/lib/ollama/useOllamaModelDetails.ts
@@ -1,4 +1,3 @@
-import { updateConfig } from '@/lib/db/database'
 import { useLogger } from '@/lib/logging/useLogger'
 import { useQuery } from '@tanstack/react-query'
 
@@ -6,7 +5,6 @@ export interface UseOllamaModelDetailsProps {
   serverUrl?: string
   model?: string
   disabled?: boolean
-  variant: 'autocompletion' | 'writing-improvements'
 }
 
 export interface OllamaModelDetailsResponse {
@@ -28,7 +26,6 @@ export function useOllamaModelDetails({
   serverUrl,
   model,
   disabled,
-  variant,
 }: UseOllamaModelDetailsProps) {
   const logger = useLogger()
   return useQuery<OllamaModelDetailsResponse | { status: 'missing' }>({
@@ -56,16 +53,6 @@ export function useOllamaModelDetails({
           serverUrl,
           model,
         })
-
-        if (variant) {
-          await updateConfig({
-            key:
-              variant === 'autocompletion'
-                ? 'completion_model'
-                : 'improvement_model',
-            value: '',
-          })
-        }
 
         return {
           status: 'missing',

--- a/src/lib/ollama/useOllamaModelDetails.ts
+++ b/src/lib/ollama/useOllamaModelDetails.ts
@@ -16,12 +16,11 @@ export interface OllamaModelDetailsResponse {
   model_info: Record<string, unknown>
 }
 
-export const OLLAMA_MODEL_BASE_QUERY_KEY = 'ollama-model-details'
-export const OLLAMA_MODEL_QUERY_KEY = (serverUrl?: string, model?: string) => [
-  OLLAMA_MODEL_BASE_QUERY_KEY,
-  serverUrl,
-  model,
-]
+export const OLLAMA_MODEL_DETAILS_BASE_QUERY_KEY = 'ollama-model-details'
+export const OLLAMA_MODEL_DETAILS_QUERY_KEY = (
+  serverUrl?: string,
+  model?: string,
+) => [OLLAMA_MODEL_DETAILS_BASE_QUERY_KEY, serverUrl, model]
 
 export function useOllamaModelDetails({
   serverUrl,
@@ -30,7 +29,7 @@ export function useOllamaModelDetails({
 }: UseOllamaModelDetailsProps) {
   const logger = useLogger()
   return useQuery<OllamaModelDetailsResponse | { status: 'missing' }>({
-    queryKey: OLLAMA_MODEL_QUERY_KEY(serverUrl, model),
+    queryKey: OLLAMA_MODEL_DETAILS_QUERY_KEY(serverUrl, model),
     queryFn: async () => {
       if (!serverUrl) {
         throw new Error('Server URL is required to fetch model details')

--- a/src/lib/ollama/useOllamaModelDetails.ts
+++ b/src/lib/ollama/useOllamaModelDetails.ts
@@ -1,3 +1,4 @@
+import { updateConfig } from '@/lib/db/database'
 import { useLogger } from '@/lib/logging/useLogger'
 import { useQuery } from '@tanstack/react-query'
 
@@ -5,6 +6,7 @@ export interface UseOllamaModelDetailsProps {
   serverUrl?: string
   model?: string
   disabled?: boolean
+  variant: 'autocompletion' | 'writing-improvements'
 }
 
 export interface OllamaModelDetailsResponse {
@@ -26,6 +28,7 @@ export function useOllamaModelDetails({
   serverUrl,
   model,
   disabled,
+  variant,
 }: UseOllamaModelDetailsProps) {
   const logger = useLogger()
   return useQuery<OllamaModelDetailsResponse | { status: 'missing' }>({
@@ -49,10 +52,20 @@ export function useOllamaModelDetails({
       )
 
       if (!response.ok) {
-        logger.info('model-details', 'Model is missing.', {
+        logger.warn('model-details', 'Model is missing.', {
           serverUrl,
           model,
         })
+
+        if (variant) {
+          await updateConfig({
+            key:
+              variant === 'autocompletion'
+                ? 'completion_model'
+                : 'improvement_model',
+            value: '',
+          })
+        }
 
         return {
           status: 'missing',

--- a/src/lib/ollama/useOllamaModels.ts
+++ b/src/lib/ollama/useOllamaModels.ts
@@ -12,9 +12,9 @@ export interface OllamaModelsResponse {
   models: OllamaModel[]
 }
 
-export const OLLAMA_MODEL_BASE_QUERY_KEY = 'ollama-model'
-export const OLLAMA_MODEL_QUERY_KEY = (serverUrl: string) => [
-  OLLAMA_MODEL_BASE_QUERY_KEY,
+export const OLLAMA_MODELS_BASE_QUERY_KEY = 'ollama-models'
+export const OLLAMA_MODELS_QUERY_KEY = (serverUrl: string) => [
+  OLLAMA_MODELS_BASE_QUERY_KEY,
   serverUrl,
 ]
 
@@ -45,7 +45,7 @@ export function useOllamaModels(serverUrl?: string | null, disabled?: boolean) {
   const targetServerUrl = serverUrl || ''
 
   return useQuery({
-    queryKey: OLLAMA_MODEL_QUERY_KEY(targetServerUrl),
+    queryKey: OLLAMA_MODELS_QUERY_KEY(targetServerUrl),
     queryFn: () => fetchOllamaModels(targetServerUrl),
     retry: false,
     enabled: !disabled,

--- a/src/lib/ollama/usePullOllamaModel.ts
+++ b/src/lib/ollama/usePullOllamaModel.ts
@@ -17,13 +17,15 @@ export interface PullModelResponseChunk {
   completed?: number
 }
 
+export const PULL_MODEL_STATUS_BASE_QUERY_KEY = 'model-status'
+
 export function usePullOllamaModel(
   { serverUrl, model, disabled }: UsePullOllamaModelProps = { disabled: false },
 ) {
   const logger = useLogger()
 
   return useQuery<PullModelResponseChunk[]>({
-    queryKey: ['model-status', serverUrl, model],
+    queryKey: [PULL_MODEL_STATUS_BASE_QUERY_KEY, serverUrl, model],
     queryFn: streamedQuery({
       streamFn: ({ signal }) => {
         return {

--- a/src/lib/updater/ModelProgress.tsx
+++ b/src/lib/updater/ModelProgress.tsx
@@ -1,0 +1,57 @@
+import { ActivityIndicator } from '@/components/ActivityIndicator'
+import { DelayedActivityIndicator } from '@/components/DelayedActivityIndicator'
+import { Progress } from '@/components/ui/progress'
+import { usePullModelWithStatus } from '@/lib/modelDownload/usePullModelWithStatus'
+import { CheckCircle2, CloudDownload, XCircle } from 'lucide-react'
+
+type PullModelResponse = ReturnType<typeof usePullModelWithStatus>
+
+interface ModelProgressProps {
+  name: string
+  status: PullModelResponse['modelStatus']
+  progress: PullModelResponse['modelProgress']
+  error: PullModelResponse['modelError']
+}
+
+export function ModelProgress({
+  name,
+  status,
+  progress,
+  error,
+}: ModelProgressProps) {
+  return (
+    <div className="grid grid-cols-2 items-center w-full">
+      <div className="whitespace-nowrap font-medium">{name}</div>
+
+      <div className="shrink-0 grow flex flex-col gap-1">
+        {status === 'idle' ? (
+          <div className="flex flex-row gap-1.5 items-center text-xs text-warning motion-safe:animate-opacity-in self-end">
+            <CloudDownload className="size-3.5" />
+            <span>Not Downloaded</span>
+          </div>
+        ) : status === 'initPending' ? (
+          <DelayedActivityIndicator delay={500}>
+            Checking model...
+          </DelayedActivityIndicator>
+        ) : status === 'success' ? (
+          <div className="flex flex-row gap-1.5 items-center text-success text-sm">
+            <CheckCircle2 className="size-4" />
+            <span>Downloaded</span>
+          </div>
+        ) : (
+          <div className="flex flex-row gap-2 w-full items-center">
+            {status === 'pending' && <ActivityIndicator srOnly />}
+            <Progress value={progress} max={100} />
+          </div>
+        )}
+
+        {status === 'error' && (
+          <div className="flex items-center gap-1 text-xs text-destructive">
+            <XCircle className="size-3.5 text-destructive" />
+            <span>{error?.message || 'Failed to download model.'}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/updater/ModelProgress.tsx
+++ b/src/lib/updater/ModelProgress.tsx
@@ -30,12 +30,16 @@ export function ModelProgress({
             <span>Not Downloaded</span>
           </div>
         ) : status === 'initPending' ? (
-          <DelayedActivityIndicator delay={500}>
+          <DelayedActivityIndicator
+            delay={500}
+            className="self-end text-xs"
+            iconClassName="size-3.5"
+          >
             Checking model...
           </DelayedActivityIndicator>
         ) : status === 'success' ? (
-          <div className="flex flex-row gap-1.5 items-center text-success text-sm">
-            <CheckCircle2 className="size-4" />
+          <div className="flex flex-row gap-1.5 items-center text-success text-xs self-end">
+            <CheckCircle2 className="size-3.5" />
             <span>Downloaded</span>
           </div>
         ) : (

--- a/src/lib/updater/UpdateToast.tsx
+++ b/src/lib/updater/UpdateToast.tsx
@@ -1,8 +1,8 @@
+import { Toast } from '@/components/Toast'
 import { Button } from '@/components/ui/button'
 import { useLogger } from '@/lib/logging/useLogger'
 import { useCheckForUpdates } from '@/lib/updater/useCheckForUpdates'
 import { useUpdateApp } from '@/lib/updater/useUpdateApp'
-import { cn } from '@/lib/utils'
 import { Update } from '@tauri-apps/plugin-updater'
 import { Loader2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
@@ -12,7 +12,7 @@ export function UpdateToast() {
   const updateCheckedRef = useRef<boolean>(false)
   const { mutateAsync: checkForUpdates } = useCheckForUpdates()
   const { mutateAsync: updateApp, isPending: isUpdatePending } = useUpdateApp()
-  const [toastVisible, setToastVisible] = useState(false)
+  const [toastVisible, setToastVisible] = useState(true)
   const [updateData, setUpdateData] = useState<Update | null>(null)
   const { error: logError } = useLogger()
 
@@ -24,7 +24,7 @@ export function UpdateToast() {
     async function checkUpdateStatus() {
       try {
         const update = await checkForUpdates()
-        setToastVisible(update != null)
+        setToastVisible(true)
         setUpdateData(update)
       } catch {
         logError('updater', 'Failed to check for updates')
@@ -50,12 +50,7 @@ export function UpdateToast() {
   }
 
   return (
-    <div
-      className={cn(
-        'absolute bottom-5 left-5 z-[200] bg-neutral-200/20 dark:bg-neutral-800/20 backdrop-blur-xl border border-border rounded-md pl-3 pr-1.5 py-2 motion-safe:transition-opacity text-sm flex items-center justify-between gap-12 shadow-xs',
-        !toastVisible ? 'pointer-events-none opacity-0' : 'opacity-100',
-      )}
-    >
+    <Toast visible={toastVisible}>
       <div className="font-medium">A new version is available</div>
 
       <div className="flex items-center gap-1">
@@ -80,6 +75,6 @@ export function UpdateToast() {
           Later
         </Button>
       </div>
-    </div>
+    </Toast>
   )
 }

--- a/src/lib/updater/UpdateToast.tsx
+++ b/src/lib/updater/UpdateToast.tsx
@@ -12,7 +12,7 @@ export function UpdateToast() {
   const updateCheckedRef = useRef<boolean>(false)
   const { mutateAsync: checkForUpdates } = useCheckForUpdates()
   const { mutateAsync: updateApp, isPending: isUpdatePending } = useUpdateApp()
-  const [toastVisible, setToastVisible] = useState(true)
+  const [toastVisible, setToastVisible] = useState(false)
   const [updateData, setUpdateData] = useState<Update | null>(null)
   const { error: logError } = useLogger()
 
@@ -24,7 +24,7 @@ export function UpdateToast() {
     async function checkUpdateStatus() {
       try {
         const update = await checkForUpdates()
-        setToastVisible(true)
+        setToastVisible(update != null)
         setUpdateData(update)
       } catch {
         logError('updater', 'Failed to check for updates')

--- a/src/lib/updater/UpdateToast.tsx
+++ b/src/lib/updater/UpdateToast.tsx
@@ -12,7 +12,7 @@ export function UpdateToast() {
   const updateCheckedRef = useRef<boolean>(false)
   const { mutateAsync: checkForUpdates } = useCheckForUpdates()
   const { mutateAsync: updateApp, isPending: isUpdatePending } = useUpdateApp()
-  const [toastVisible, setToastVisible] = useState(false)
+  const [visible, setVisible] = useState(false)
   const [updateData, setUpdateData] = useState<Update | null>(null)
   const { error: logError } = useLogger()
 
@@ -24,7 +24,7 @@ export function UpdateToast() {
     async function checkUpdateStatus() {
       try {
         const update = await checkForUpdates()
-        setToastVisible(update != null)
+        setVisible(update != null)
         setUpdateData(update)
       } catch {
         logError('updater', 'Failed to check for updates')
@@ -50,7 +50,7 @@ export function UpdateToast() {
   }
 
   return (
-    <Toast visible={toastVisible}>
+    <Toast visible={visible} hideDelay={0}>
       <div className="font-medium">A new version is available</div>
 
       <div className="flex items-center gap-1">
@@ -69,7 +69,7 @@ export function UpdateToast() {
         <Button
           size="sm"
           variant="ghost"
-          onClick={() => setToastVisible(false)}
+          onClick={() => setVisible(false)}
           className="px-2"
         >
           Later

--- a/src/lib/updater/updater.ts
+++ b/src/lib/updater/updater.ts
@@ -12,8 +12,16 @@ export async function checkForUpdates(): Promise<Update | null> {
   try {
     const update = await check()
     return update
-  } catch {
-    // Fail silently
+  } catch (error) {
+    logEvent(
+      'ERROR',
+      'updater',
+      `Failed to check for updates: ${(error as Error).message}`,
+      {
+        stack: (error as Error).stack || null,
+      },
+    )
+
     return null
   }
 }

--- a/src/lib/useInvalidateQueriesOnWindowFocus.ts
+++ b/src/lib/useInvalidateQueriesOnWindowFocus.ts
@@ -1,19 +1,25 @@
 import { DOCS_FOLDER_QUERY_KEY } from '@/lib/files/useCurrentDocsFolder'
 import { FILES_AND_FOLDERS_TREE_QUERY_KEY } from '@/lib/files/useFilesAndFolders'
 import { READ_FILE_BASE_QUERY_KEY } from '@/lib/files/useReadFile'
+import { useModelDownloadContext } from '@/lib/modelDownload/useModelDownloadContext'
 import { OLLAMA_MODEL_DETAILS_BASE_QUERY_KEY } from '@/lib/ollama/useOllamaModelDetails'
-import { OLLAMA_MODEL_BASE_QUERY_KEY } from '@/lib/ollama/useOllamaModels'
+import { OLLAMA_MODELS_BASE_QUERY_KEY } from '@/lib/ollama/useOllamaModels'
 import { OLLAMA_WARMUP_BASE_QUERY_KEY } from '@/lib/ollama/useWarmupCompletionModel'
 import { useQueryClient } from '@tanstack/react-query'
 import { listen } from '@tauri-apps/api/event'
 import { useEffect, useRef } from 'react'
 
 export function useInvalidateQueriesOnWindowFocus() {
+  const { downloadStatus } = useModelDownloadContext()
   const queryClient = useQueryClient()
   const lastRefetchTime = useRef<number | null>(null)
 
   // Listen for Tauri window events
   useEffect(() => {
+    if (downloadStatus === 'pending') {
+      return
+    }
+
     let unlisten: () => void | undefined
 
     const setupListeners = async () => {
@@ -41,10 +47,7 @@ export function useInvalidateQueriesOnWindowFocus() {
             }),
             queryClient.invalidateQueries({
               predicate: (query) =>
-                query.queryKey.includes(OLLAMA_MODEL_BASE_QUERY_KEY),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: [OLLAMA_MODEL_BASE_QUERY_KEY],
+                query.queryKey.includes(OLLAMA_MODELS_BASE_QUERY_KEY),
             }),
             queryClient.invalidateQueries({
               queryKey: [OLLAMA_MODEL_DETAILS_BASE_QUERY_KEY],
@@ -62,5 +65,5 @@ export function useInvalidateQueriesOnWindowFocus() {
     setupListeners()
 
     return () => unlisten?.()
-  }, [queryClient])
+  }, [queryClient, downloadStatus])
 }

--- a/src/lib/useInvalidateQueriesOnWindowFocus.ts
+++ b/src/lib/useInvalidateQueriesOnWindowFocus.ts
@@ -1,6 +1,7 @@
 import { DOCS_FOLDER_QUERY_KEY } from '@/lib/files/useCurrentDocsFolder'
 import { FILES_AND_FOLDERS_TREE_QUERY_KEY } from '@/lib/files/useFilesAndFolders'
 import { READ_FILE_BASE_QUERY_KEY } from '@/lib/files/useReadFile'
+import { OLLAMA_MODEL_DETAILS_BASE_QUERY_KEY } from '@/lib/ollama/useOllamaModelDetails'
 import { OLLAMA_MODEL_BASE_QUERY_KEY } from '@/lib/ollama/useOllamaModels'
 import { OLLAMA_WARMUP_BASE_QUERY_KEY } from '@/lib/ollama/useWarmupCompletionModel'
 import { useQueryClient } from '@tanstack/react-query'
@@ -41,6 +42,12 @@ export function useInvalidateQueriesOnWindowFocus() {
             queryClient.invalidateQueries({
               predicate: (query) =>
                 query.queryKey.includes(OLLAMA_MODEL_BASE_QUERY_KEY),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: [OLLAMA_MODEL_BASE_QUERY_KEY],
+            }),
+            queryClient.invalidateQueries({
+              queryKey: [OLLAMA_MODEL_DETAILS_BASE_QUERY_KEY],
             }),
             queryClient.invalidateQueries({
               queryKey: [OLLAMA_WARMUP_BASE_QUERY_KEY],

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import '@fontsource-variable/inter'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router'
+import { ModelDownloadProvider } from '@/lib/modelDownload/ModelDownloadProvider'
 
 const router = createBrowserRouter([
   {
@@ -59,8 +60,10 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
       disableTransitionOnChange
     >
       <QueryProvider>
-        <RouterProvider router={router} />
-        <Toaster />
+        <ModelDownloadProvider>
+          <RouterProvider router={router} />
+          <Toaster />
+        </ModelDownloadProvider>
       </QueryProvider>
     </ThemeProvider>
   </React.StrictMode>,

--- a/src/pages/editor/MarkdownPreview.tsx
+++ b/src/pages/editor/MarkdownPreview.tsx
@@ -84,7 +84,8 @@ export const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({
           onContextMenu={showContextMenu}
           className={cn(
             '-mt-12 px-4 prose prose-sm max-w-none prose-headings:text-neutral-900 prose-p:text-neutral-700 prose-strong:text-neutral-900 prose-blockquote:border-l-4 prose-blockquote:border-neutral-300 prose-blockquote:text-neutral-600 [&_ul_ul]:ml-4 [&_ol_ol]:ml-4 [&_ul_ol]:ml-4 [&_ol_ul]:ml-4 [&_li_ul]:ml-4 [&_li_ol]:ml-4 select-auto cursor-auto',
-            renderType === 'embedded' && 'mt-0 px-0 overflow-hidden w-full',
+            renderType === 'embedded' &&
+              'mt-0 px-0 overflow-hidden w-full select-none',
             previewClassName,
           )}
         >

--- a/src/pages/onboarding/steps/DownloadModelsStep.tsx
+++ b/src/pages/onboarding/steps/DownloadModelsStep.tsx
@@ -52,6 +52,7 @@ export function DownloadModelsStep({ onNext }: DownloadModelsStepProps) {
     disabled: !downloadEnabled || isOllamaDisconnected,
     model: RECOMMENDED_AUTOCOMPLETION_MODEL.name,
     connected: isOllamaConnected,
+    variant: 'autocompletion',
   })
 
   const {
@@ -62,6 +63,7 @@ export function DownloadModelsStep({ onNext }: DownloadModelsStepProps) {
     disabled: !downloadEnabled || isOllamaDisconnected,
     model: RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name,
     connected: isOllamaConnected,
+    variant: 'writing-improvements',
   })
 
   const isDownloading =

--- a/src/pages/onboarding/steps/DownloadModelsStep.tsx
+++ b/src/pages/onboarding/steps/DownloadModelsStep.tsx
@@ -9,7 +9,7 @@ import {
 import { DEFAULT_OLLAMA_URL } from '@/lib/ollama/ollama'
 import { useOllamaConnection } from '@/lib/ollama/useOllamaConnection'
 import { ModelCardWithProgress } from '@/pages/onboarding/steps/ModelCardWithProgress'
-import { usePullModelWithStatus } from '@/pages/onboarding/steps/usePullModelWithStatus'
+import { usePullModelWithStatus } from '@/lib/modelDownload/usePullModelWithStatus'
 import { AdvancedOptionsDialog } from '@/pages/onboarding/steps/AdvancedOptionsDialog'
 import { AlertCircle, Sparkles, Zap } from 'lucide-react'
 import { useTheme } from 'next-themes'

--- a/src/pages/onboarding/steps/DownloadModelsStep.tsx
+++ b/src/pages/onboarding/steps/DownloadModelsStep.tsx
@@ -52,7 +52,6 @@ export function DownloadModelsStep({ onNext }: DownloadModelsStepProps) {
     disabled: !downloadEnabled || isOllamaDisconnected,
     model: RECOMMENDED_AUTOCOMPLETION_MODEL.name,
     connected: isOllamaConnected,
-    variant: 'autocompletion',
   })
 
   const {
@@ -63,7 +62,6 @@ export function DownloadModelsStep({ onNext }: DownloadModelsStepProps) {
     disabled: !downloadEnabled || isOllamaDisconnected,
     model: RECOMMENDED_WRITING_IMPROVEMENTS_MODEL.name,
     connected: isOllamaConnected,
-    variant: 'writing-improvements',
   })
 
   const isDownloading =


### PR DESCRIPTION
## Summary

- **In-app model downloads**: Users can now download Ollama models directly from the settings panel instead of using the command line
- **Global download tracking**: Added  to track download progress across the entire app with real-time status updates
- **Toast notifications**: Display model download progress and completion status with a reusable toast component
- **Improved UX**: Integrated download panel into AI assistant settings, with automatic model selector switching after successful downloads
- **Refactored hooks**: Extracted and moved  to a shared location for reusability

## Changes

- New  and  for global download state management
- New  component for selecting and downloading models
- New  component for displaying download progress
- New  component for rendering download progress UI
- Refactored toast system with improved layout and styling
- Updated logging utilities to support download status tracking
- Improved Ollama model hooks for better progress tracking
- Enhanced layout to support persistent download notifications
